### PR TITLE
Hotfix of failing test "should find a user mail without differentiating between upper- and lowercase"

### DIFF
--- a/__tests__/routes/authRoutes.test.js
+++ b/__tests__/routes/authRoutes.test.js
@@ -59,7 +59,7 @@ describe('Login User route', () => {
       expect(202);
 
       // Verify the response body
-      expect(response.body.user.email).toBe('fake@gmail.com');
+      expect(response.body.userInfo.email).toBe('fake@gmail.com');
   });
 
   it('Returns error if user is not found', async () => {


### PR DESCRIPTION
Hotfix of failing test 'should find a user mail without differentiating between upper- and lowercase'. User is changed to userinfo.