### PR TITLE
Add student profilePhoto routes and functionality 

### DIFF
--- a/models/Students.js
+++ b/models/Students.js
@@ -20,6 +20,9 @@ const studentSchema = new Schema({
 		type: Schema.Types.ObjectId,
 		ref: 'Courses'
 	}],
+	profilePhoto: {
+		type: String,
+	},
 	courses: [
 		{
 			courseId: {

--- a/routes/studentRoutes.js
+++ b/routes/studentRoutes.js
@@ -39,168 +39,168 @@ router.get('/:id/info', async (req, res) => {
 /** Profile Photos **/
 //Get user profile photo
 router.get('/:id/photo', async (req, res) => {
- 	const id = mongoose.Types.ObjectId(req.params.id);
+    const id = mongoose.Types.ObjectId(req.params.id);
 
- 	if (!serviceUrl) {
- 		return res.status(500).json({ message: 'Service URL is missing' });
- 	}
+    if (!serviceUrl) {
+        return res.status(500).json({ message: 'Service URL is missing' });
+    }
 
- 	if (!id) {
- 		return res.status(400).json({ error: errorCodes['E0202'] });
- 	}
+    if (!id) {
+        return res.status(400).json({ error: errorCodes['E0202'] });
+    }
 
- 	try {
-		const student = await StudentModel.findOne({ baseUser: id });
+    try {
+        const student = await StudentModel.findOne({ baseUser: id });
 
- 		if (!student) {
- 			return res.status(404).json({ message: 'Student not found' });
- 		}
+        if (!student) {
+            return res.status(404).json({ message: 'Student not found' });
+        }
 
- 		if (!student.profilePhoto) {
- 			return res.status(200).send(null);
- 		}
+        if (!student.profilePhoto) {
+            return res.status(200).send(null);
+        }
 
- 		// Get the photo from the bucket api
- 		axios.get(serviceUrl + '/bucket/' + student.profilePhoto).then((response) => {
-			res.send(response.data);
- 		}).catch((error) => {
- 			if (error.response && error.response.data) {
- 				// Forward the status code from the Axios error if available
- 				res.status(error.response.status || 500).send(error.response.data);
- 			} else {
- 				console.log(error);
- 				// Handle cases where the error does not have a response part (like network errors)
- 				res.status(500).send({ message: 'An error occurred during fetching.' });
- 			}
- 		});
- 	} catch (error) {
- 		return res.status(500).json({ message: 'Internal server error' });
- 	}
+        // Get the photo from the bucket api
+        axios.get(serviceUrl + '/bucket/' + student.profilePhoto).then((response) => {
+            res.send(response.data);
+        }).catch((error) => {
+            if (error.response && error.response.data) {
+                // Forward the status code from the Axios error if available
+                res.status(error.response.status || 500).send(error.response.data);
+            } else {
+                console.log(error);
+                // Handle cases where the error does not have a response part (like network errors)
+                res.status(500).send({ message: 'An error occurred during fetching.' });
+            }
+        });
+    } catch (error) {
+        return res.status(500).json({ message: 'Internal server error' });
+    }
 });
 
 //Update user profile photo
 router.put('/:id/photo', upload.single('file'), async (req, res) => {
- 	const id = mongoose.Types.ObjectId(req.params.id);
+    const id = mongoose.Types.ObjectId(req.params.id);
 
- 	const profilePhoto = req.file;
+    const profilePhoto = req.file;
 
-	if (!(profilePhoto.mimetype == 'image/jpeg' || profilePhoto.mimetype == 'image/png')) {
-		return res.status(400).json({ message: 'Invalid file type' });
-	}
+    if (!(profilePhoto.mimetype == 'image/jpeg' || profilePhoto.mimetype == 'image/png')) {
+        return res.status(400).json({ message: 'Invalid file type' });
+    }
 
- 	// Require userID
- 	if (!id) {
- 		return res.status(400).json({ error: errorCodes['E0202'] });
- 	}
+    // Require userID
+    if (!id) {
+        return res.status(400).json({ error: errorCodes['E0202'] });
+    }
 
- 	if (!profilePhoto) {
- 		return res.status(400).json({ message: 'No file uploaded' });
- 	}
+    if (!profilePhoto) {
+        return res.status(400).json({ message: 'No file uploaded' });
+    }
 
- 	// Rename userPhoto to photo + timestamp
- 	const timestamp = new Date().getTime();
-	const fileExtension = req.file.originalname.split('.').pop();
- 	const photoName = `${id}-${timestamp}.${fileExtension}`;
- 	profilePhoto.filename = photoName;
+    // Rename userPhoto to photo + timestamp
+    const timestamp = new Date().getTime();
+    const fileExtension = req.file.originalname.split('.').pop();
+    const photoName = `${id}-${timestamp}.${fileExtension}`;
+    profilePhoto.filename = photoName;
 
- 	try {
- 		const student = await StudentModel.findOne({ baseUser: id });
+    try {
+        const student = await StudentModel.findOne({ baseUser: id });
 
- 		if (!student) {
- 			return res.status(404).json({ message: 'User not found' });
- 		}
+        if (!student) {
+            return res.status(404).json({ message: 'User not found' });
+        }
 
- 		// If user has photo, then delete it from the bucket
- 		if (student.profilePhoto) {
- 			try {
- 				await deleteImageFromBucket(student.profilePhoto);
- 			} catch {
- 				console.log('Error deleting file from bucket');
- 			}
- 		}
+        // If user has photo, then delete it from the bucket
+        if (student.profilePhoto) {
+            try {
+                await deleteImageFromBucket(student.profilePhoto);
+            } catch {
+                console.log('Error deleting file from bucket');
+            }
+        }
 
- 		// Upload the new photo to the bucket
- 		try {
- 			await uploadImageToBucket(profilePhoto);
- 		} catch {
- 			return res.status(500).json({ message: 'Error uploading file to bucket' });
- 		}
+        // Upload the new photo to the bucket
+        try {
+            await uploadImageToBucket(profilePhoto);
+        } catch {
+            return res.status(500).json({ message: 'Error uploading file to bucket' });
+        }
 
- 		// Update profle with new userPhoto
- 		const updatedStudent = await StudentModel.findOneAndUpdate(
- 			{ baseUser: id },
- 			{ profilePhoto: photoName },
- 			{ new: true }
- 		);
+        // Update profle with new userPhoto
+        const updatedStudent = await StudentModel.findOneAndUpdate(
+			{ baseUser: id },
+            { profilePhoto: photoName },
+            { new: true }
+        );
 
- 		return res.status(200).json(updatedStudent);
- 	} catch (error) {
- 		return res.status(500).json({ message: 'Internal server error' });
- 	}
+        return res.status(200).json(updatedStudent);
+    } catch (error) {
+        return res.status(500).json({ message: 'Internal server error' });
+    }
 });
 
 const uploadImageToBucket = async (file) => {
- 	if (!serviceUrl) {
- 		throw new Error('Service URL is missing');
- 	}
+    if (!serviceUrl) {
+        throw new Error('Service URL is missing');
+    }
 
- 	const form = new FormData();
+    const form = new FormData();
 
- 	// Add file and filename to form
- 	form.append('file', file.buffer, {
- 		filename: file.filename,
- 		contentType: file.mimetype
- 	});
- 	form.append('fileName', file.filename);
+    // Add file and filename to form
+    form.append('file', file.buffer, {
+        filename: file.filename,
+        contentType: file.mimetype
+    });
+    form.append('fileName', file.filename);
 
- 	// Forward to service api
- 	await axios.post(serviceUrl + '/bucket/', form, { headers: form.getHeaders() })
- 		.then(response => {
- 			return response.data;
- 		}).catch(error => {
- 			console.log(error.response);
- 			throw new Error('An error occurred during upload.');
- 		});
+    // Forward to service api
+    await axios.post(serviceUrl + '/bucket/', form, { headers: form.getHeaders() })
+        .then(response => {
+            return response.data;
+        }).catch(error => {
+            console.log(error.response);
+            throw new Error('An error occurred during upload.');
+        });
 };
 
 //Delete user profile photo
 router.delete('/:id/photo', async (req, res) => {
- 	const id = mongoose.Types.ObjectId(req.params.id);
+    const id = mongoose.Types.ObjectId(req.params.id);
 
- 	// Require userID
- 	if (!id) {
- 		return res.status(400).json({ error: errorCodes['E0202'] });
- 	}
+    // Require userID
+    if (!id) {
+        return res.status(400).json({ error: errorCodes['E0202'] });
+    }
 
- 	try {
- 		const student = await StudentModel.findOne({ baseUser: id });
+    try {
+        const student = await StudentModel.findOne({ baseUser: id });
 
- 		if (!student) {
- 			return res.status(404).json({ message: 'User not found' });
- 		}
+        if (!student) {
+            return res.status(404).json({ message: 'User not found' });
+        }
 
- 		// If user has photo, then delete it from the bucket
- 		if (student.profilePhoto) {
- 			await deleteImageFromBucket(student.profilePhoto);
- 		}
+        // If user has photo, then delete it from the bucket
+        if (student.profilePhoto) {
+            await deleteImageFromBucket(student.profilePhoto);
+        }
 
- 		const updatedStudent = await StudentModel.findOneAndUpdate(
- 			{ baseUser: id },
- 			{ userPhoto: null },
- 			{ new: true }
- 		);
+        const updatedStudent = await StudentModel.findOneAndUpdate(
+            { baseUser: id },
+            { userPhoto: null },
+            { new: true }
+        );
 
- 		return res.status(200).json(updatedStudent);
- 	} catch (error) {
- 		return res.status(500).json({ message: 'Internal server error' });
- 	}
+        return res.status(200).json(updatedStudent);
+    } catch (error) {
+        return res.status(500).json({ message: 'Internal server error' });
+    }
 });
 
 const deleteImageFromBucket = async (filename) => {
- 	//Forward to service api
- 	await axios.delete(serviceUrl + '/bucket/' + filename).then((response) => {
- 		return response.data;
- 	});
+    //Forward to service api
+    await axios.delete(serviceUrl + '/bucket/' + filename).then((response) => {
+        return response.data;
+    });
 };
 
 /** SUBSCRIPTIONS **/

--- a/routes/studentRoutes.js
+++ b/routes/studentRoutes.js
@@ -39,168 +39,168 @@ router.get('/:id/info', async (req, res) => {
 /** Profile Photos **/
 //Get user profile photo
 router.get('/:id/photo', async (req, res) => {
-    const id = mongoose.Types.ObjectId(req.params.id);
+	const id = mongoose.Types.ObjectId(req.params.id);
 
-    if (!serviceUrl) {
-        return res.status(500).json({ message: 'Service URL is missing' });
-    }
+	if (!serviceUrl) {
+		return res.status(500).json({ message: 'Service URL is missing' });
+	}
 
-    if (!id) {
-        return res.status(400).json({ error: errorCodes['E0202'] });
-    }
+	if (!id) {
+		return res.status(400).json({ error: errorCodes['E0202'] });
+	}
 
-    try {
-        const student = await StudentModel.findOne({ baseUser: id });
+	try {
+		const student = await StudentModel.findOne({ baseUser: id });
 
-        if (!student) {
-            return res.status(404).json({ message: 'Student not found' });
-        }
+		if (!student) {
+			return res.status(404).json({ message: 'Student not found' });
+		}
 
-        if (!student.profilePhoto) {
-            return res.status(200).send(null);
-        }
+		if (!student.profilePhoto) {
+			return res.status(200).send(null);
+		}
 
-        // Get the photo from the bucket api
-        axios.get(serviceUrl + '/bucket/' + student.profilePhoto).then((response) => {
-            res.send(response.data);
-        }).catch((error) => {
-            if (error.response && error.response.data) {
-                // Forward the status code from the Axios error if available
-                res.status(error.response.status || 500).send(error.response.data);
-            } else {
-                console.log(error);
-                // Handle cases where the error does not have a response part (like network errors)
-                res.status(500).send({ message: 'An error occurred during fetching.' });
-            }
-        });
-    } catch (error) {
-        return res.status(500).json({ message: 'Internal server error' });
-    }
+		// Get the photo from the bucket api
+		axios.get(serviceUrl + '/bucket/' + student.profilePhoto).then((response) => {
+			res.send(response.data);
+		}).catch((error) => {
+			if (error.response && error.response.data) {
+				// Forward the status code from the Axios error if available
+				res.status(error.response.status || 500).send(error.response.data);
+			} else {
+				console.log(error);
+				// Handle cases where the error does not have a response part (like network errors)
+				res.status(500).send({ message: 'An error occurred during fetching.' });
+			}
+		});
+	} catch (error) {
+		return res.status(500).json({ message: 'Internal server error' });
+	}
 });
 
 //Update user profile photo
 router.put('/:id/photo', upload.single('file'), async (req, res) => {
-    const id = mongoose.Types.ObjectId(req.params.id);
+	const id = mongoose.Types.ObjectId(req.params.id);
 
-    const profilePhoto = req.file;
+	const profilePhoto = req.file;
 
-    if (!(profilePhoto.mimetype == 'image/jpeg' || profilePhoto.mimetype == 'image/png')) {
-        return res.status(400).json({ message: 'Invalid file type' });
-    }
+	if (!(profilePhoto.mimetype == 'image/jpeg' || profilePhoto.mimetype == 'image/png')) {
+		return res.status(400).json({ message: 'Invalid file type' });
+	}
 
-    // Require userID
-    if (!id) {
-        return res.status(400).json({ error: errorCodes['E0202'] });
-    }
+	// Require userID
+	if (!id) {
+		return res.status(400).json({ error: errorCodes['E0202'] });
+	}
 
-    if (!profilePhoto) {
-        return res.status(400).json({ message: 'No file uploaded' });
-    }
+	if (!profilePhoto) {
+		return res.status(400).json({ message: 'No file uploaded' });
+	}
 
-    // Rename userPhoto to photo + timestamp
-    const timestamp = new Date().getTime();
-    const fileExtension = req.file.originalname.split('.').pop();
-    const photoName = `${id}-${timestamp}.${fileExtension}`;
-    profilePhoto.filename = photoName;
+	// Rename userPhoto to photo + timestamp
+	const timestamp = new Date().getTime();
+	const fileExtension = req.file.originalname.split('.').pop();
+	const photoName = `${id}-${timestamp}.${fileExtension}`;
+	profilePhoto.filename = photoName;
 
-    try {
-        const student = await StudentModel.findOne({ baseUser: id });
+	try {
+		const student = await StudentModel.findOne({ baseUser: id });
 
-        if (!student) {
-            return res.status(404).json({ message: 'User not found' });
-        }
+		if (!student) {
+			return res.status(404).json({ message: 'User not found' });
+		}
 
-        // If user has photo, then delete it from the bucket
-        if (student.profilePhoto) {
-            try {
-                await deleteImageFromBucket(student.profilePhoto);
-            } catch {
-                console.log('Error deleting file from bucket');
-            }
-        }
+		// If user has photo, then delete it from the bucket
+		if (student.profilePhoto) {
+			try {
+				await deleteImageFromBucket(student.profilePhoto);
+			} catch {
+				console.log('Error deleting file from bucket');
+			}
+		}
 
-        // Upload the new photo to the bucket
-        try {
-            await uploadImageToBucket(profilePhoto);
-        } catch {
-            return res.status(500).json({ message: 'Error uploading file to bucket' });
-        }
+		// Upload the new photo to the bucket
+		try {
+			await uploadImageToBucket(profilePhoto);
+		} catch {
+			return res.status(500).json({ message: 'Error uploading file to bucket' });
+		}
 
-        // Update profle with new userPhoto
-        const updatedStudent = await StudentModel.findOneAndUpdate(
+		// Update profle with new userPhoto
+		const updatedStudent = await StudentModel.findOneAndUpdate(
 			{ baseUser: id },
-            { profilePhoto: photoName },
-            { new: true }
-        );
+			{ profilePhoto: photoName },
+			{ new: true }
+		);
 
-        return res.status(200).json(updatedStudent);
-    } catch (error) {
-        return res.status(500).json({ message: 'Internal server error' });
-    }
+		return res.status(200).json(updatedStudent);
+	} catch (error) {
+		return res.status(500).json({ message: 'Internal server error' });
+	}
 });
 
 const uploadImageToBucket = async (file) => {
-    if (!serviceUrl) {
-        throw new Error('Service URL is missing');
-    }
+	if (!serviceUrl) {
+		throw new Error('Service URL is missing');
+	}
 
-    const form = new FormData();
+	const form = new FormData();
 
-    // Add file and filename to form
-    form.append('file', file.buffer, {
-        filename: file.filename,
-        contentType: file.mimetype
-    });
-    form.append('fileName', file.filename);
+	// Add file and filename to form
+	form.append('file', file.buffer, {
+		filename: file.filename,
+		contentType: file.mimetype
+	});
+	form.append('fileName', file.filename);
 
-    // Forward to service api
-    await axios.post(serviceUrl + '/bucket/', form, { headers: form.getHeaders() })
-        .then(response => {
-            return response.data;
-        }).catch(error => {
-            console.log(error.response);
-            throw new Error('An error occurred during upload.');
-        });
+	// Forward to service api
+	await axios.post(serviceUrl + '/bucket/', form, { headers: form.getHeaders() })
+		.then(response => {
+			return response.data;
+		}).catch(error => {
+			console.log(error.response);
+			throw new Error('An error occurred during upload.');
+		});
 };
 
 //Delete user profile photo
 router.delete('/:id/photo', async (req, res) => {
-    const id = mongoose.Types.ObjectId(req.params.id);
+	const id = mongoose.Types.ObjectId(req.params.id);
 
-    // Require userID
-    if (!id) {
-        return res.status(400).json({ error: errorCodes['E0202'] });
-    }
+	// Require userID
+	if (!id) {
+		return res.status(400).json({ error: errorCodes['E0202'] });
+	}
 
-    try {
-        const student = await StudentModel.findOne({ baseUser: id });
+	try {
+		const student = await StudentModel.findOne({ baseUser: id });
 
-        if (!student) {
-            return res.status(404).json({ message: 'User not found' });
-        }
+		if (!student) {
+			return res.status(404).json({ message: 'User not found' });
+		}
 
-        // If user has photo, then delete it from the bucket
-        if (student.profilePhoto) {
-            await deleteImageFromBucket(student.profilePhoto);
-        }
+		// If user has photo, then delete it from the bucket
+		if (student.profilePhoto) {
+			await deleteImageFromBucket(student.profilePhoto);
+		}
 
-        const updatedStudent = await StudentModel.findOneAndUpdate(
-            { baseUser: id },
-            { userPhoto: null },
-            { new: true }
-        );
+		const updatedStudent = await StudentModel.findOneAndUpdate(
+			{ baseUser: id },
+			{ userPhoto: null },
+			{ new: true }
+		);
 
-        return res.status(200).json(updatedStudent);
-    } catch (error) {
-        return res.status(500).json({ message: 'Internal server error' });
-    }
+		return res.status(200).json(updatedStudent);
+	} catch (error) {
+		return res.status(500).json({ message: 'Internal server error' });
+	}
 });
 
 const deleteImageFromBucket = async (filename) => {
-    //Forward to service api
-    await axios.delete(serviceUrl + '/bucket/' + filename).then((response) => {
-        return response.data;
-    });
+	//Forward to service api
+	await axios.delete(serviceUrl + '/bucket/' + filename).then((response) => {
+		return response.data;
+	});
 };
 
 /** SUBSCRIPTIONS **/

--- a/routes/studentRoutes.js
+++ b/routes/studentRoutes.js
@@ -7,6 +7,14 @@ const { findTop100Students } = require('../helpers/leaderboard');
 const { addIncompleteCourse } = require('../helpers/completing');
 const { StudentModel } = require('../models/Students');
 const { CourseModel } = require('../models/Courses');
+const multer = require('multer');
+const axios = require('axios');
+const FormData = require('form-data');
+const process = require('process');
+const storage = multer.memoryStorage();
+const upload = multer({ storage: storage });
+
+const serviceUrl = process.env.TRANSCODER_SERVICE_URL;
 
 router.get('/:id/info', async (req, res) => {
 	try {
@@ -27,6 +35,173 @@ router.get('/:id/info', async (req, res) => {
 		return res.status(500).send({ error: errorCodes['E0003'] });
 	}
 });
+
+/** Profile Photos **/
+//Get user profile photo
+router.get('/:id/photo', async (req, res) => {
+ 	const id = mongoose.Types.ObjectId(req.params.id);
+
+ 	if (!serviceUrl) {
+ 		return res.status(500).json({ message: 'Service URL is missing' });
+ 	}
+
+ 	if (!id) {
+ 		return res.status(400).json({ error: errorCodes['E0202'] });
+ 	}
+
+ 	try {
+		const student = await StudentModel.findOne({ baseUser: id });
+
+ 		if (!student) {
+ 			return res.status(404).json({ message: 'Student not found' });
+ 		}
+
+ 		if (!student.profilePhoto) {
+ 			return res.status(200).send(null);
+ 		}
+
+ 		// Get the photo from the bucket api
+ 		axios.get(serviceUrl + '/bucket/' + student.profilePhoto).then((response) => {
+			res.send(response.data);
+ 		}).catch((error) => {
+ 			if (error.response && error.response.data) {
+ 				// Forward the status code from the Axios error if available
+ 				res.status(error.response.status || 500).send(error.response.data);
+ 			} else {
+ 				console.log(error);
+ 				// Handle cases where the error does not have a response part (like network errors)
+ 				res.status(500).send({ message: 'An error occurred during fetching.' });
+ 			}
+ 		});
+ 	} catch (error) {
+ 		return res.status(500).json({ message: 'Internal server error' });
+ 	}
+});
+
+//Update user profile photo
+router.put('/:id/photo', upload.single('file'), async (req, res) => {
+ 	const id = mongoose.Types.ObjectId(req.params.id);
+
+ 	const profilePhoto = req.file;
+
+	if (!(profilePhoto.mimetype == 'image/jpeg' || profilePhoto.mimetype == 'image/png')) {
+		return res.status(400).json({ message: 'Invalid file type' });
+	}
+
+ 	// Require userID
+ 	if (!id) {
+ 		return res.status(400).json({ error: errorCodes['E0202'] });
+ 	}
+
+ 	if (!profilePhoto) {
+ 		return res.status(400).json({ message: 'No file uploaded' });
+ 	}
+
+ 	// Rename userPhoto to photo + timestamp
+ 	const timestamp = new Date().getTime();
+	const fileExtension = req.file.originalname.split('.').pop();
+ 	const photoName = `${id}-${timestamp}.${fileExtension}`;
+ 	profilePhoto.filename = photoName;
+
+ 	try {
+ 		const student = await StudentModel.findOne({ baseUser: id });
+
+ 		if (!student) {
+ 			return res.status(404).json({ message: 'User not found' });
+ 		}
+
+ 		// If user has photo, then delete it from the bucket
+ 		if (student.profilePhoto) {
+ 			try {
+ 				await deleteImageFromBucket(student.profilePhoto);
+ 			} catch {
+ 				console.log('Error deleting file from bucket');
+ 			}
+ 		}
+
+ 		// Upload the new photo to the bucket
+ 		try {
+ 			await uploadImageToBucket(profilePhoto);
+ 		} catch {
+ 			return res.status(500).json({ message: 'Error uploading file to bucket' });
+ 		}
+
+ 		// Update profle with new userPhoto
+ 		const updatedStudent = await StudentModel.findOneAndUpdate(
+ 			{ baseUser: id },
+ 			{ profilePhoto: photoName },
+ 			{ new: true }
+ 		);
+
+ 		return res.status(200).json(updatedStudent);
+ 	} catch (error) {
+ 		return res.status(500).json({ message: 'Internal server error' });
+ 	}
+});
+
+const uploadImageToBucket = async (file) => {
+ 	if (!serviceUrl) {
+ 		throw new Error('Service URL is missing');
+ 	}
+
+ 	const form = new FormData();
+
+ 	// Add file and filename to form
+ 	form.append('file', file.buffer, {
+ 		filename: file.filename,
+ 		contentType: file.mimetype
+ 	});
+ 	form.append('fileName', file.filename);
+
+ 	// Forward to service api
+ 	await axios.post(serviceUrl + '/bucket/', form, { headers: form.getHeaders() })
+ 		.then(response => {
+ 			return response.data;
+ 		}).catch(error => {
+ 			console.log(error.response);
+ 			throw new Error('An error occurred during upload.');
+ 		});
+};
+
+//Delete user profile photo
+router.delete('/:id/photo', async (req, res) => {
+ 	const id = mongoose.Types.ObjectId(req.params.id);
+
+ 	// Require userID
+ 	if (!id) {
+ 		return res.status(400).json({ error: errorCodes['E0202'] });
+ 	}
+
+ 	try {
+ 		const student = await StudentModel.findOne({ baseUser: id });
+
+ 		if (!student) {
+ 			return res.status(404).json({ message: 'User not found' });
+ 		}
+
+ 		// If user has photo, then delete it from the bucket
+ 		if (student.profilePhoto) {
+ 			await deleteImageFromBucket(student.profilePhoto);
+ 		}
+
+ 		const updatedStudent = await StudentModel.findOneAndUpdate(
+ 			{ baseUser: id },
+ 			{ userPhoto: null },
+ 			{ new: true }
+ 		);
+
+ 		return res.status(200).json(updatedStudent);
+ 	} catch (error) {
+ 		return res.status(500).json({ message: 'Internal server error' });
+ 	}
+});
+
+const deleteImageFromBucket = async (filename) => {
+ 	//Forward to service api
+ 	await axios.delete(serviceUrl + '/bucket/' + filename).then((response) => {
+ 		return response.data;
+ 	});
+};
 
 /** SUBSCRIPTIONS **/
 


### PR DESCRIPTION
## Description

This PR adds the "profilePhoto" field to student models, along with routes to the backend for fetching, uploading and deleting profile photos. This solves the backend side of the issue #153.

On update and delete, we update the user's profile to change / remove the "profilePhoto" string.

Must have TRANSCODER_SERVICE_URL in .env

## Changes

Added three new endpoints to the /profiles endpoint:
- GET: /students/:id/photo (Fetches a student's profilePhoto from transcoding service)
- PUT: /students/:id/photo(Upload's and replaces a student's profilePhoto from transcoding service)
- DELETE: /students/:id/photo (Deletes a student's profilePhoto from transcoding service)

## Related Issues

#153 
Mobile issue: https://github.com/Educado-App/educado-mobile/issues/257

## Checklist

- [x] Code has been tested locally and passes all relevant tests.
- [x] Documentation has been updated to reflect the changes, if applicable.
- [x] Code follows the established coding style and guidelines of the project.
- [x] All new and existing tests related to the changes have passed.
- [x] Any necessary dependencies or new packages have been properly documented.
- [x] Pull request title and description are clear and descriptive.
- [x] Reviewers have been assigned to the pull request.
- [x] Any potential security implications have been considered and addressed.
- [x] Performance impact of the changes has been evaluated, if relevant.

## Screenshots (if applicable)
<img width="827" alt="Screenshot 2024-09-21 at 13 33 47" src="https://github.com/user-attachments/assets/0c2daad7-c9b5-4393-b8b6-64951d5169a7">
