### PR TITLE
Deadlocked publish course

### DIFF
--- a/__tests__/fixtures/fakeCourse.js
+++ b/__tests__/fixtures/fakeCourse.js
@@ -6,7 +6,7 @@ module.exports = function makeFakeCourse() {
 		dateCreated: Date.now(),
 		dateUpdated: Date.now(),
 		category: 'sewing',
-		published: false,
+		status: 'draft',
 		sections: [],
 		difficulty: 1,
 		estimatedHours: 1,
@@ -14,3 +14,4 @@ module.exports = function makeFakeCourse() {
 		numOfSubscriptions: 0,
 	};
 };
+

--- a/__tests__/fixtures/fakeCoursePublished.js
+++ b/__tests__/fixtures/fakeCoursePublished.js
@@ -1,0 +1,15 @@
+module.exports = function makeFakeCoursePublished(){
+	return {
+		title: 'test course published',
+		description: 'test course description',
+		dateCreated: Date.now(),
+		dateUpdated: Date.now(),
+		category: 'sewing',
+		status: 'published',
+		sections: [],
+		difficulty: 1,
+		estimatedHours: 1,
+		rating: 5,
+		numOfSubscriptions: 0,
+	};
+};

--- a/__tests__/routes/courseRoutes.test.js
+++ b/__tests__/routes/courseRoutes.test.js
@@ -12,6 +12,7 @@ const makeFakeCreator = require('../fixtures/fakeContentCreator');
 const makeFakeStudent = require('../fixtures/fakeStudent');
 const makeFakeLecture = require('../fixtures/fakeLecture');
 const makeFakeExercise = require('../fixtures/fakeExercise');
+const makeFakeCoursePublished = require('../fixtures/fakeCoursePublished');
 const { getFakeCourses, getFakeCoursesByCreator } = require('../fixtures/fakeCourses');
 const { addIncompleteCourse } = require('../../helpers/completing');
 
@@ -42,6 +43,7 @@ let fakeSection = makeFakeSection();
 let fakeCourses = getFakeCourses();
 let fakeLection = makeFakeLecture();
 let fakeExercise = makeFakeExercise();
+let fakeCoursePublished = makeFakeCoursePublished();
 
 const COMP_TYPES = {
 	LECTURE: 'lecture',
@@ -820,9 +822,9 @@ describe('Course Routes', () => {
 
 			expect(course.status).toBe('draft');
 
-			const response = await request(app)
-				.patch('api/courses/' + courseId + '/updateStatus')
-				.set('Authorization', `Bearer ${token}`)
+			const response = await request(`http://localhost:${PORT}`)
+				.patch('/api/courses/' + courseId + '/updateStatus')
+				.set('token', signAccessToken({ id: fakeUser._id }))
 				.send({ status : "published"})
 				.expect(200);
 			
@@ -830,7 +832,32 @@ describe('Course Routes', () => {
 			const updatedCourse = await db.collection('courses').findOne({ _id : courseId });
 			expect(response.status).toBe(200);
 
-			expect(updatedCourse.status).toBe('published')
+			expect(updatedCourse.status).toBe('published');
+		});
+	});
+
+	describe('PATCH /courses/:courseId/updateStatus', () => {
+		it('Update status of the fake course to draft', async () => {
+
+			//set up a published course in db
+			await db.collection('courses').insertOne(fakeCoursePublished);
+		
+			const course = await db.collection('courses').findOne({ title: 'test course published' });
+			const courseId = course._id;
+
+			expect(course.status).toBe('published');
+
+			const response = await request(`http://localhost:${PORT}`)
+				.patch('/api/courses/' + courseId + '/updateStatus')
+				.set('token', signAccessToken({ id: fakeUser._id }))
+				.send({ status : "draft"})
+				.expect(200);
+			
+			
+			const updatedCourse = await db.collection('courses').findOne({ _id : courseId });
+			expect(response.status).toBe(200);
+
+			expect(updatedCourse.status).toBe('draft');
 		});
 	});
 });

--- a/__tests__/routes/courseRoutes.test.js
+++ b/__tests__/routes/courseRoutes.test.js
@@ -811,5 +811,27 @@ describe('Course Routes', () => {
 			expect(response.body.estimatedHours).toBe(2);
 		});
 	});
+
+	describe('PATCH /courses/:courseId/updateStatus', () => {
+		it('Update status of the fake course to published', async () => {
+
+			const course = await db.collection('courses').findOne({ title: 'test course' });
+			const courseId = course._id;
+
+			expect(course.status).toBe('draft');
+
+			const response = await request(app)
+				.patch('api/courses/' + courseId + '/updateStatus')
+				.set('Authorization', `Bearer ${token}`)
+				.send({ status : "published"})
+				.expect(200);
+			
+			
+			const updatedCourse = await db.collection('courses').findOne({ _id : courseId });
+			expect(response.status).toBe(200);
+
+			expect(updatedCourse.status).toBe('published')
+		});
+	});
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "passport": "^0.6.0",
         "passport-google-oauth20": "^2.0.0",
         "prettier": "^3.0.3",
+        "server": "file:",
         "supertest": "^6.3.3"
       },
       "devDependencies": {
@@ -17331,6 +17332,10 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/server": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "passport": "^0.6.0",
     "passport-google-oauth20": "^2.0.0",
     "prettier": "^3.0.3",
+    "server": "file:",
     "supertest": "^6.3.3"
   },
   "devDependencies": {

--- a/routes/componentRoutes.js
+++ b/routes/componentRoutes.js
@@ -33,6 +33,7 @@ router.get('/:type/:id', async (req, res) => {
  * route to patch the components in a section
  * @param {string} sectionId
  */
+//this function was deleting components unintentionally, for now it's deprecated. 
 router.patch('/:sectionId', async (req, res) => {
 	// const { sectionId } = req.params;
 	// const { components } = req.body;
@@ -59,7 +60,7 @@ router.patch('/:sectionId', async (req, res) => {
 	// // section.components = components;
 	// // await section.save();
 	// res.send(section);
-	res.send(200);
+	res.send('OK');
 });
 
 module.exports = router;

--- a/routes/courseRoutes.js
+++ b/routes/courseRoutes.js
@@ -470,21 +470,16 @@ router.delete('/:id'/*, requireLogin*/, async (req, res) => {
 });
 
 
-// Update course published state
+// Update course published status 
+// Status is enum: "published", "draft", "hidden"
 router.patch('/updateStatus', async (req, res) => {
-	const { published, course_id } = req.body;
+	const { status, course_id } = req.body;
 
 	// find object in database and update title to new value
-	// (
-	// 	await CourseModel.findOneAndUpdate(
-	// 		{ _id: course_id },
-	// 		{ published: published }
-	// 	)
-	// ).save;
 	(
 		await CourseModel.findOneAndUpdate(
 			{ _id: course_id },
-			{ status: published }
+			{ status: status }
 		)
 	).save;
 	const course = await CourseModel.findById(course_id);

--- a/routes/courseRoutes.js
+++ b/routes/courseRoutes.js
@@ -471,14 +471,20 @@ router.delete('/:id'/*, requireLogin*/, async (req, res) => {
 
 
 // Update course published state
-router.patch('/published', async (req, res) => {
+router.patch('/updateStatus', async (req, res) => {
 	const { published, course_id } = req.body;
 
 	// find object in database and update title to new value
+	// (
+	// 	await CourseModel.findOneAndUpdate(
+	// 		{ _id: course_id },
+	// 		{ published: published }
+	// 	)
+	// ).save;
 	(
 		await CourseModel.findOneAndUpdate(
 			{ _id: course_id },
-			{ published: published }
+			{ status: published }
 		)
 	).save;
 	const course = await CourseModel.findById(course_id);

--- a/routes/courseRoutes.js
+++ b/routes/courseRoutes.js
@@ -473,7 +473,7 @@ router.delete('/:id'/*, requireLogin*/, async (req, res) => {
 // Update course published status 
 // Status is enum: "published", "draft", "hidden"
 router.patch('/updateStatus', async (req, res) => {
-	const { status, course_id } = req.body;
+	const {course_id, status } = req.body;
 
 	// find object in database and update title to new value
 	(

--- a/routes/courseRoutes.js
+++ b/routes/courseRoutes.js
@@ -472,17 +472,18 @@ router.delete('/:id'/*, requireLogin*/, async (req, res) => {
 
 // Update course published status 
 // Status is enum: "published", "draft", "hidden"
-router.patch('/updateStatus', async (req, res) => {
-	const {course_id, status } = req.body;
+router.patch('/:id/updateStatus', async (req, res) => {
+	const { status } = req.body;
+	const { id } = req.params;
 
 	// find object in database and update title to new value
 	(
 		await CourseModel.findOneAndUpdate(
-			{ _id: course_id },
+			{ _id: id },
 			{ status: status }
 		)
 	).save;
-	const course = await CourseModel.findById(course_id);
+	const course = await CourseModel.findById(id);
 
 	// Send response
 	res.send(course);


### PR DESCRIPTION
## Description

Updated backend routes to use when publishing a course so it is done properly.

## Changes
Updated a previously deprecated route for publishing a course, now as 'updateStatus' which can change the status of a course between any of 'draft', 'published', 'hidden.

## Related Issues

https://github.com/orgs/Educado-App/projects/14/views/12?pane=issue&itemId=79909539

## Checklist

- [x] Code has been tested locally and passes all relevant tests.
- [x] Documentation has been updated to reflect the changes, if applicable.
- [x] Code follows the established coding style and guidelines of the project.
- [x] All new and existing tests related to the changes have passed.
- [x] Any necessary dependencies or new packages have been properly documented.
- [x] Pull request title and description are clear and descriptive.
- [] Reviewers have been assigned to the pull request.
- [x] Any potential security implications have been considered and addressed.
- [x] Performance impact of the changes has been evaluated, if relevant.

## Notes for Reviewers

The status variable is provided from the frontend. And the course ID is passed as a parameter of the api endpoint.