### PR TITLE
Student Study Streak (PBI #370)

### DIFF
--- a/__tests__/helpers/studentHelper.test.js
+++ b/__tests__/helpers/studentHelper.test.js
@@ -1,77 +1,124 @@
 const mongoose = require('mongoose');
-const { updateStudyStreak, ensureStudyStreakConsistency } = require('../../helpers/studentHelper');
+const { updateStudyStreak, differenceInDays, ensureStudyStreakConsistency } = require('../../helpers/studentHelper');
 const { StudentModel } = require('../../models/Students');
-const { CustomError } = require('../../helpers/error');
-const errorCodes = require('../../helpers/errorCodes');
 
-jest.mock('../../models/Students');
+// Mock mongoose, database model and functions
+jest.mock('mongoose');
+jest.mock('../../models/Students', () => ({ 
+    StudentModel: { 
+        findById: jest.fn(), 
+        findByIdAndUpdate: jest.fn() 
+    } 
+}));
 
 describe('studentHelper', () => {
-    const mockId = '1234567890abcdef12345678';
-    const today = new Date();
-    let lastStudyDate;
+    let mockStudent;
     let originalConsoleError;
+    const mockId = new mongoose.Types.ObjectId('1234567890abcdef12345678');
+    const today = new Date();
+    const yesterday = new Date(today);
+    const twoDaysAgo = new Date(today);
+    const sevenDaysAgo = new Date(today);
+    
+    // Set preceeding days
+    yesterday.setDate(today.getDate() - 1);
+    twoDaysAgo.setDate(today.getDate() - 2);
+    sevenDaysAgo.setDate(today.getDate() - 7);
     
     beforeEach(() => {
-        lastStudyDate = new Date();
-
         // Suppress console.error during tests by mocking it
         originalConsoleError = console.error;
         console.error = jest.fn();
     });
     
     afterEach(() => {
-        lastStudyDate = null;
+        mockStudent = null;
         jest.clearAllMocks();
         console.error = originalConsoleError; // Restore console.error
     });
 
     describe('updateStudyStreak', () => {
         it('should increment studyStreak if student also studied yesterday', async () => {
-            const studyStreak = 5;
-            lastStudyDate.setDate(today.getDate() - 1); // Yesterday
+            mockStudent = {
+                studyStreak: 3,
+                lastStudyDate: yesterday,
+            };
 
-        }); 
+            StudentModel.findById.mockReturnValue({
+                select: jest.fn().mockResolvedValue(mockStudent)
+            });
+            StudentModel.findByIdAndUpdate.mockResolvedValue({});
+       
+            await updateStudyStreak(mockId);
+        
+            expect(StudentModel.findById).toHaveBeenCalledWith(mockId);
+            expect(StudentModel.findByIdAndUpdate).toHaveBeenCalledWith(mockId, expect.objectContaining({ studyStreak: 4 }));
+        });    
 
-        it('should update lastStudyDate if student also studied yesterday', async () => {
+        it('should soft reset studyStreak if it has been broken', async () => {
+            mockStudent = {
+                studyStreak: 3,
+                lastStudyDate: twoDaysAgo,
+            };
 
-        });
-
-        it('should reset studyStreak if it has been broken', async () => {
-
-        });
-
-        it('should throw custom error (errorCode E0019) if update fails', async () => {
-           
+            StudentModel.findById.mockReturnValue({
+                select: jest.fn().mockResolvedValue(mockStudent)
+            });
+            StudentModel.findByIdAndUpdate.mockResolvedValue({});
+        
+            await updateStudyStreak(mockId);
+        
+            expect(StudentModel.findById).toHaveBeenCalledWith(mockId);
+            expect(StudentModel.findByIdAndUpdate).toHaveBeenCalledWith(mockId, expect.objectContaining({ studyStreak: 1 }));
         });
     });
 
-    describe('ensureStudyStreakConsistency', () => {
-        it('should reset studyStreak if it has been broken', async () => {
-            lastStudyDate.setDate(lastStudyDate.getDate() - 2); // 2 days ago
+    describe('differenceInDays', () => {
+        it('should return 0 if dates are the same', () => {
+            const result = differenceInDays(today, today);
+            expect(result).toBe(0);
+        });
 
+        it('should return 1 if dates are one day apart', () => {
+            const result = differenceInDays(yesterday, today);
+            expect(result).toBe(1);
+        });
+
+        it('should return 7 if the dates are seven days apart', () => {
+            const result = differenceInDays(sevenDaysAgo, today);
+            expect(result).toBe(7);
+        });
+        
+        it('should throw an error if either date is not a Date instance', () => {
+            const notDateInstance = '2024-11-29T00:00:00.000Z';
+            expect(() => differenceInDays(notDateInstance, today)).toThrow('lastStudyDate/currentDate is not a Date instance!');
+        });
+        
+        it('should throw an error if either date is not a valid date', () => {
+            const invalidDate = new Date('invalid date');
+            expect(() => differenceInDays(invalidDate, today)).toThrow('lastStudyDate/currentDate is not a valid date!');
+        });
+    });
+    
+    describe('ensureStudyStreakConsistency', () => {
+        it('should hard reset studyStreak if it has been broken', async () => {
             StudentModel.findByIdAndUpdate.mockResolvedValue({});
 
-            await ensureStudyStreakConsistency(mockId, lastStudyDate);
+            await ensureStudyStreakConsistency(mockId, twoDaysAgo);
 
             expect(StudentModel.findByIdAndUpdate).toHaveBeenCalledWith(mockId, { studyStreak: 0 });
         });
 
         it('should not reset studyStreak if it has not been broken', async () => {
-            lastStudyDate.setDate(lastStudyDate.getDate() - 1); // Yesterday
-
-            await ensureStudyStreakConsistency(mockId, lastStudyDate);
+            await ensureStudyStreakConsistency(mockId, yesterday);
 
             expect(StudentModel.findByIdAndUpdate).not.toHaveBeenCalled();
         });
 
         it('should log an error if ensureStudyStreakConsistency fails', async () => {
-            lastStudyDate.setDate(lastStudyDate.getDate() - 2); // 2 days ago
-            StudentModel.findByIdAndUpdate.mockRejectedValue(new Error('Failed to ensure study streak consistency!'));
+            StudentModel.findByIdAndUpdate.mockRejectedValue(new Error());
 
-            console.error = jest.fn();
-
-            await ensureStudyStreakConsistency(mockId, lastStudyDate);
+            await ensureStudyStreakConsistency(mockId, twoDaysAgo);
 
             expect(console.error).toHaveBeenCalledWith('Failed to ensure study streak consistency!');
         });

--- a/__tests__/helpers/studentHelper.test.js
+++ b/__tests__/helpers/studentHelper.test.js
@@ -1,0 +1,79 @@
+const mongoose = require('mongoose');
+const { updateStudyStreak, ensureStudyStreakConsistency } = require('../../helpers/studentHelper');
+const { StudentModel } = require('../../models/Students');
+const { CustomError } = require('../../helpers/error');
+const errorCodes = require('../../helpers/errorCodes');
+
+jest.mock('../../models/Students');
+
+describe('studentHelper', () => {
+    const mockId = '1234567890abcdef12345678';
+    const today = new Date();
+    let lastStudyDate;
+    let originalConsoleError;
+    
+    beforeEach(() => {
+        lastStudyDate = new Date();
+
+        // Suppress console.error during tests by mocking it
+        originalConsoleError = console.error;
+        console.error = jest.fn();
+    });
+    
+    afterEach(() => {
+        lastStudyDate = null;
+        jest.clearAllMocks();
+        console.error = originalConsoleError; // Restore console.error
+    });
+
+    describe('updateStudyStreak', () => {
+        it('should increment studyStreak if student also studied yesterday', async () => {
+            const studyStreak = 5;
+            lastStudyDate.setDate(today.getDate() - 1); // Yesterday
+
+        }); 
+
+        it('should update lastStudyDate if student also studied yesterday', async () => {
+
+        });
+
+        it('should reset studyStreak if it has been broken', async () => {
+
+        });
+
+        it('should throw custom error (errorCode E0019) if update fails', async () => {
+           
+        });
+    });
+
+    describe('ensureStudyStreakConsistency', () => {
+        it('should reset studyStreak if it has been broken', async () => {
+            lastStudyDate.setDate(lastStudyDate.getDate() - 2); // 2 days ago
+
+            StudentModel.findByIdAndUpdate.mockResolvedValue({});
+
+            await ensureStudyStreakConsistency(mockId, lastStudyDate);
+
+            expect(StudentModel.findByIdAndUpdate).toHaveBeenCalledWith(mockId, { studyStreak: 0 });
+        });
+
+        it('should not reset studyStreak if it has not been broken', async () => {
+            lastStudyDate.setDate(lastStudyDate.getDate() - 1); // Yesterday
+
+            await ensureStudyStreakConsistency(mockId, lastStudyDate);
+
+            expect(StudentModel.findByIdAndUpdate).not.toHaveBeenCalled();
+        });
+
+        it('should log an error if ensureStudyStreakConsistency fails', async () => {
+            lastStudyDate.setDate(lastStudyDate.getDate() - 2); // 2 days ago
+            StudentModel.findByIdAndUpdate.mockRejectedValue(new Error('Failed to ensure study streak consistency!'));
+
+            console.error = jest.fn();
+
+            await ensureStudyStreakConsistency(mockId, lastStudyDate);
+
+            expect(console.error).toHaveBeenCalledWith('Failed to ensure study streak consistency!');
+        });
+    });
+});

--- a/helpers/errorCodes.js
+++ b/helpers/errorCodes.js
@@ -78,10 +78,6 @@ module.exports = {
 		code: 'E0018',
 		message: 'Failed to delete all account data from database!'
 	},
-	E0019: {
-		code: 'E0019',
-		message: 'Failed to update student study streak!'
-	},
 
 	// E01 - Login errors
 	E0101: {
@@ -281,6 +277,10 @@ module.exports = {
 	E0806: {
 		code: 'E0806',
 		message: 'Old password is incorrect.'
+	},
+	E0807: {
+		code: 'E0807',
+		message: 'Failed to update student study streak!'
 	},
 
 	// E09 - Answer Exercises Errors

--- a/helpers/errorCodes.js
+++ b/helpers/errorCodes.js
@@ -78,6 +78,10 @@ module.exports = {
 		code: 'E0018',
 		message: 'Failed to delete all account data from database!'
 	},
+	E0019: {
+		code: 'E0019',
+		message: 'Failed to update student study streak!'
+	},
 
 	// E01 - Login errors
 	E0101: {

--- a/helpers/studentHelper.js
+++ b/helpers/studentHelper.js
@@ -7,25 +7,25 @@ const { StudentModel } = require('../models/Students');
 
 /**
  * @function updateStudyStreak
- * @description Increment the study streak if the student studied yesterday, else reset it if the streak has been broken.
+ * @description Increments studyStreak and updates lastStudyDate if student also studied yesterday, 
+ * 				else soft resets it as the streak has been broken but a new is beginning now.
  * @param {ObjectId} id - The ID of the student.
- * @throws {CustomError} - Throws a custom error (errorCode 'E0019') if the update fails.
+ * @throws {CustomError} - Throws a custom error (errorCode 'E0807') if the update fails.
  */
 async function updateStudyStreak(id) {
 	try {
 		const { studyStreak, lastStudyDate } = await StudentModel.findById(id).select('studyStreak lastStudyDate');
 		const currentDate = new Date();
 		const dayDifference = differenceInDays(lastStudyDate, currentDate);
-
+		
 		if (dayDifference === 1)
 			await StudentModel.findByIdAndUpdate(id, { studyStreak: studyStreak + 1, lastStudyDate: currentDate});
 		else if (dayDifference > 1)
 			await StudentModel.findByIdAndUpdate(id, { studyStreak: 1, lastStudyDate: currentDate });
 	}
 	catch (error) {
-		console.error(error.message);	// TODO: suppress in unit test!
-		// TODO: update resources documents!
-		throw new CustomError(errorCodes.E0019); // 'Failed to update student study streak!'
+		console.error(error.message);
+		throw new CustomError(errorCodes.E0807); // 'Failed to update student study streak!'
 	}
 }
 
@@ -51,7 +51,7 @@ function differenceInDays(lastStudyDate, currentDate) {
 	return differenceInDays;
 }
 
-// Check if student is on a study streak, and if not, reset the streak (invoked when student logs in)
+// Check if student is on a study streak, and if not, hard reset the streak (invoked when student logs in)
 async function ensureStudyStreakConsistency(id, lastStudyDate) {
 	try {    
 		const currentDate = new Date();
@@ -62,8 +62,8 @@ async function ensureStudyStreakConsistency(id, lastStudyDate) {
 			await StudentModel.findByIdAndUpdate(id, { studyStreak: 0 });
 	}
 	catch (error) {
-		console.error('Failed to ensure study streak consistency!');	// TODO: suppress in unit test!
+		console.error('Failed to ensure study streak consistency!');
 	}
 }
 
-module.exports = { updateStudyStreak, ensureStudyStreakConsistency };
+module.exports = { updateStudyStreak, differenceInDays, ensureStudyStreakConsistency };

--- a/helpers/studentHelper.js
+++ b/helpers/studentHelper.js
@@ -1,0 +1,81 @@
+// Helpers
+const mongoose = require('mongoose');
+const errorCodes = require('./errorCodes');
+const { CustomError } = require('./error');
+
+// Models
+const { StudentModel } = require('../models/Students');
+
+async function updateStudyStreak(id) {
+	const session = await mongoose.startSession();
+	
+	try {
+		session.startTransaction();
+
+		const currentStudyStreak = await StudentModel.findOne({ baseUser: id }).select('studyStreak');
+		const lastStudyDate = await StudentModel.findOne({ baseUser: id }).select('lastStudyDate');
+		const currentDate = new Date();
+
+		const differenceInDays = handleDateDifference(lastStudyDate, currentDate);
+
+		if (differenceInDays === 1)
+			await StudentModel.updateOne({ baseUser: id }, { studyStreak: currentStudyStreak + 1 }, { session });
+		else if (differenceInDays > 1)
+			await StudentModel.updateOne({ baseUser: id }, { studyStreak: 1 }, { session });
+
+		// Update last study date
+		await StudentModel.updateOne({ baseUser: id }, { lastStudyDate: currentDate }, { session });
+
+		await session.commitTransaction();
+	}
+	catch (error) {
+		// Cancel database operations in case of failure
+		await session.abortTransaction();
+
+		// TODO: update resources documents!
+		throw new CustomError(errorCodes.E0019); // 'Failed to update student study streak!'
+	}
+	finally {
+		await session.endSession();
+	}
+}
+
+function handleDateDifference(lastStudyDate, currentDate) {
+    
+	// Check if the provided values are instances of the Date object
+	if (!(lastStudyDate instanceof Date) || !(currentDate instanceof Date))
+		throw new Error('Invalid date(s) provided.');
+
+	// Check if the dates are valid
+	if (isNaN(lastStudyDate.getTime()) || isNaN(currentDate.getTime()))
+		throw new Error('Invalid date(s) provided.');
+
+	// Get dates without time, by setting the time to midnight
+	const startDate = new Date(lastStudyDate.getFullYear(), lastStudyDate.getMonth(), lastStudyDate.getDate());
+	const endDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
+
+	// Calculate the difference in milliseconds, and convert it to days
+	const differenceInMs = endDate - startDate;
+	const differenceInDays = differenceInMs / (1000 * 60 * 60 * 24);
+
+	return differenceInDays;
+}
+
+// Check if student is on a study streak, and if not, reset the streak
+async function ensureStudyStreak(id) {
+	try {    
+		const lastStudyDate = await StudentModel.findOne({ baseUser: id }).select('lastStudyDate');
+		const currentDate = new Date();
+
+		const differenceInDays = handleDateDifference(lastStudyDate, currentDate);
+
+		if (differenceInDays > 1)
+			await StudentModel.updateOne({ baseUser: id }, { studyStreak: 0 });
+	}
+	catch (error) {
+		// TODO: update resources documents!
+		throw new CustomError(errorCodes.E0019); // 'Failed to update student study streak!'
+	}
+}
+
+module.exports = { updateStudyStreak, ensureStudyStreak };

--- a/helpers/studentHelper.js
+++ b/helpers/studentHelper.js
@@ -1,76 +1,71 @@
 // Helpers
-const mongoose = require('mongoose');
 const errorCodes = require('./errorCodes');
 const { CustomError } = require('./error');
 
 // Models
 const { StudentModel } = require('../models/Students');
 
+// Increment studyStreak if student studied yesterday, else reset it if streak has been broken
 async function updateStudyStreak(id) {
-	const session = await mongoose.startSession();
-	
 	try {
-		session.startTransaction();
-
-		const currentStudyStreak = await StudentModel.findOne({ baseUser: id }).select('studyStreak');
-		const lastStudyDate = await StudentModel.findOne({ baseUser: id }).select('lastStudyDate');
+		const { studyStreak, lastStudyDate } = await StudentModel.findById(id).select('studyStreak lastStudyDate');
 		const currentDate = new Date();
 
 		const differenceInDays = handleDateDifference(lastStudyDate, currentDate);
 
-		if (differenceInDays === 1)
-			await StudentModel.updateOne({ baseUser: id }, { studyStreak: currentStudyStreak + 1 }, { session });
-		else if (differenceInDays > 1)
-			await StudentModel.updateOne({ baseUser: id }, { studyStreak: 1 }, { session });
-
-		// Update last study date
-		await StudentModel.updateOne({ baseUser: id }, { lastStudyDate: currentDate }, { session });
-
-		await session.commitTransaction();
+		if (differenceInDays === 1) {
+			await StudentModel.findByIdAndUpdate(id, { studyStreak: studyStreak + 1, lastStudyDate: currentDate});
+			console.log("Study streak incremented!");		// TODO: REMOVE
+		}
+		else if (differenceInDays > 1) {
+			await StudentModel.findByIdAndUpdate(id, { studyStreak: 1, lastStudyDate: currentDate });
+			console.log("Study streak reset!");		// TODO: REMOVE
+		}
 	}
 	catch (error) {
-		// Cancel database operations in case of failure
-		await session.abortTransaction();
-
+		console.error(error.message);	// TODO: suppress in unit test!
 		// TODO: update resources documents!
 		throw new CustomError(errorCodes.E0019); // 'Failed to update student study streak!'
-	}
-	finally {
-		await session.endSession();
 	}
 }
 
 function handleDateDifference(lastStudyDate, currentDate) {
-    
-	// Check if the provided values are instances of the Date object
+	// Instance check
 	if (!(lastStudyDate instanceof Date) || !(currentDate instanceof Date))
-		throw new Error('Invalid date(s) provided.');
+		throw new Error('lastStudyDate is not a Date instance!');
 
-	// Check if the dates are valid
+	// Validity check
 	if (isNaN(lastStudyDate.getTime()) || isNaN(currentDate.getTime()))
-		throw new Error('Invalid date(s) provided.');
+		throw new Error('lastStudyDate is not valid!');
 
-	// Get dates without time, by setting the time to midnight
+	// Get dates without time by setting the time to midnight
 	const startDate = new Date(lastStudyDate.getFullYear(), lastStudyDate.getMonth(), lastStudyDate.getDate());
 	const endDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
-
+	
 	// Calculate the difference in milliseconds, and convert it to days
 	const differenceInMs = endDate - startDate;
+
+	// E.g., the difference in days between monday 23:59 and tuesday 00:01 is still 1 day
 	const differenceInDays = differenceInMs / (1000 * 60 * 60 * 24);
+	console.log("Difference in days: " + differenceInDays);
 
 	return differenceInDays;
 }
 
-// Check if student is on a study streak, and if not, reset the streak
-async function ensureStudyStreak(id) {
+// Check if student is on a study streak, and if not, reset the streak (invoked when student logs in)
+async function ensureStudyStreakConsistency(id, lastStudyDate) {
 	try {    
-		const lastStudyDate = await StudentModel.findOne({ baseUser: id }).select('lastStudyDate');
 		const currentDate = new Date();
-
 		const differenceInDays = handleDateDifference(lastStudyDate, currentDate);
 
-		if (differenceInDays > 1)
-			await StudentModel.updateOne({ baseUser: id }, { studyStreak: 0 });
+		// Reset studyStreak if streak has been broken
+		if (differenceInDays > 1) {
+			await StudentModel.findByIdAndUpdate(id, { studyStreak: 0 });
+			console.log("Study streak reset!");	// TODO: remove
+		}
+		else {
+			console.log("Student is study active!");	// TODO: remove
+		}
 	}
 	catch (error) {
 		// TODO: update resources documents!
@@ -78,4 +73,4 @@ async function ensureStudyStreak(id) {
 	}
 }
 
-module.exports = { updateStudyStreak, ensureStudyStreak };
+module.exports = { updateStudyStreak, ensureStudyStreakConsistency };

--- a/models/Students.js
+++ b/models/Students.js
@@ -14,7 +14,7 @@ const studentSchema = new Schema({
 	},
 	level: {
 		type: Number,
-		default: 0
+		default: 1
 	},
 	studyStreak: {
 		type: Number,

--- a/models/Students.js
+++ b/models/Students.js
@@ -22,7 +22,11 @@ const studentSchema = new Schema({
 	},
 	lastStudyDate: {
 		type: Date,
-		default: Date.now
+		default: () => {
+			const yesterday = new Date();
+			yesterday.setDate(yesterday.getDate() - 1);
+			return yesterday;
+		}
 	},
 	subscriptions: [{
 		type: Schema.Types.ObjectId,

--- a/models/Students.js
+++ b/models/Students.js
@@ -14,7 +14,15 @@ const studentSchema = new Schema({
 	},
 	level: {
 		type: Number,
-		default: 1
+		default: 0
+	},
+	studyStreak: {
+		type: Number,
+		default: 0
+	},
+	lastStudyDate: {
+		type: Date,
+		default: Date.now
 	},
 	subscriptions: [{
 		type: Schema.Types.ObjectId,

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -14,7 +14,7 @@ const { PasswordResetToken } = require('../models/PasswordResetToken');
 const { EmailVerificationToken } = require('../models/EmailVerificationToken');
 const { validateEmail, validateName, validatePassword } = require('../helpers/validation');
 const { sendVerificationEmail } = require('../helpers/email');
-const { ensureStudyStreak } = require('../helpers/studentHelper');
+const { ensureStudyStreakConsistency } = require('../helpers/studentHelper');
 
 const bcrypt = require('bcrypt');
 // Utility function to encrypt the token or password
@@ -71,10 +71,9 @@ router.post('/login', async (req, res) => {
 			profile = await StudentModel.findOne({baseUser: user._id});
 
 			// Ensure student is on a study streak, else reset the streak
-			//ensureStudyStreak(profile.baseUser);	// <- Here 'profile' is the student object
+			// TODO: handle error thrown!
+			ensureStudyStreakConsistency(profile._id, profile.lastStudyDate);	// <- Here 'profile' is the student object
 		}
-
-
 
 		// If the passwords match, return a success message
 		if (result) {
@@ -176,14 +175,11 @@ router.post('/signup', async (req, res) => {
 			// Create content creator and student profiles
 			const contentCreatorProfile = new ContentCreatorModel({ baseUser: newUser._id });
 			const studentProfile = new StudentModel({ baseUser: newUser._id });
-			console.log("studentProfile: " + studentProfile);	// TODO: remove
 
 			// Save the user and profiles
 			const createdUser = await newUser.save();  // Save user
 			let createdContentCreator = await contentCreatorProfile.save(); // Save content creator
 			const createdStudent = await studentProfile.save(); // Save student
-			console.log("createdStudent: " + createdStudent);	// TODO: remove
-
 
 			// Respond with the created user and institution data
 			res.status(201).json({

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -70,9 +70,8 @@ router.post('/login', async (req, res) => {
 		} else {
 			profile = await StudentModel.findOne({baseUser: user._id});
 
-			// Ensure student is on a study streak, else reset the streak
-			// TODO: handle error thrown!
-			ensureStudyStreakConsistency(profile._id, profile.lastStudyDate);	// <- Here 'profile' is the student object
+			// Ensure student is on a study streak, else reset their streak
+			ensureStudyStreakConsistency(profile._id, profile.lastStudyDate);	// <- Notice: here 'profile' is the student object
 		}
 
 		// If the passwords match, return a success message

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -71,7 +71,7 @@ router.post('/login', async (req, res) => {
 			profile = await StudentModel.findOne({baseUser: user._id});
 
 			// Ensure student is on a study streak, else reset the streak
-			ensureStudyStreak(profile.baseUser);	// <- Here 'profile' is the student object
+			//ensureStudyStreak(profile.baseUser);	// <- Here 'profile' is the student object
 		}
 
 
@@ -175,7 +175,7 @@ router.post('/signup', async (req, res) => {
 
 			// Create content creator and student profiles
 			const contentCreatorProfile = new ContentCreatorModel({ baseUser: newUser._id });
-			const studentProfile = new StudentModel({ baseUser: newUser._id, studyStreak: 42 });
+			const studentProfile = new StudentModel({ baseUser: newUser._id });
 			console.log("studentProfile: " + studentProfile);	// TODO: remove
 
 			// Save the user and profiles

--- a/routes/studentRoutes.js
+++ b/routes/studentRoutes.js
@@ -13,6 +13,8 @@ const FormData = require('form-data');
 const process = require('process');
 const storage = multer.memoryStorage();
 const upload = multer({ storage: storage });
+const { updateStudyStreak } = require('../helpers/studentHelper');
+const { assert } = require('../helpers/error');
 
 const serviceUrl = process.env.TRANSCODER_SERVICE_URL;
 
@@ -391,5 +393,31 @@ router.get('/leaderboard', async (req, res) => {
 		}
 	}
 });
+
+// TODO: update route documentation!
+// Update studyStreak
+router.patch('/:id/updateStudyStreak', requireLogin, async (req, res) => {
+	try {
+		// Ensure passed in id is valid
+		assert(mongoose.Types.ObjectId.isValid(req.params.id), errorCodes.E0014);
+		const id = mongoose.Types.ObjectId(req.params.id);	
+
+		//await updateStudyStreak(id);
+
+		return res.status(200).json({ message: 'Student study streak updated!' });
+	} 
+	catch (error) {
+		console.error(error.message);		// TODO: suppress in tests
+		switch(error.code) {
+		case 'E0014':
+			return res.status(400).send({ error: error.message }); // 'Invalid id'
+		case 'E0019':
+			return res.status(500).send({ error: error.message }); //'Failed to update student study streak!'
+		default:
+			return res.status(500).json({ error: errorCodes['E0003'].message }); // 'Server could not be reached'
+		}
+	}
+});
+
 
 module.exports = router;

--- a/routes/studentRoutes.js
+++ b/routes/studentRoutes.js
@@ -394,7 +394,6 @@ router.get('/leaderboard', async (req, res) => {
 	}
 });
 
-// TODO: update route documentation!
 // Update studyStreak
 router.patch('/:id/updateStudyStreak', async (req, res) => {
 	try {
@@ -407,7 +406,7 @@ router.patch('/:id/updateStudyStreak', async (req, res) => {
 		return res.status(200).json({ message: 'Student study streak updated!' });
 	} 
 	catch (error) {
-		console.error(error.message);		// TODO: suppress in tests
+		console.error(error.message);
 		switch(error.code) {
 		case 'E0014':
 			return res.status(400).send({ error: error.message }); // 'Invalid id'

--- a/routes/studentRoutes.js
+++ b/routes/studentRoutes.js
@@ -399,11 +399,10 @@ router.get('/leaderboard', async (req, res) => {
 router.patch('/:id/updateStudyStreak', async (req, res) => {
 	try {
 		// Ensure passed in id is valid
-		// assert(mongoose.Types.ObjectId.isValid(req.params.id), errorCodes.E0014);
-		const id = mongoose.Types.ObjectId(req.params.id);	
-		console.log("StudentId: ", id);
+		assert(mongoose.Types.ObjectId.isValid(req.params.id), errorCodes.E0014);
+		const studentId = mongoose.Types.ObjectId(req.params.id);	
 
-		//await updateStudyStreak(id);
+		await updateStudyStreak(studentId);
 
 		return res.status(200).json({ message: 'Student study streak updated!' });
 	} 

--- a/routes/studentRoutes.js
+++ b/routes/studentRoutes.js
@@ -396,11 +396,12 @@ router.get('/leaderboard', async (req, res) => {
 
 // TODO: update route documentation!
 // Update studyStreak
-router.patch('/:id/updateStudyStreak', requireLogin, async (req, res) => {
+router.patch('/:id/updateStudyStreak', async (req, res) => {
 	try {
 		// Ensure passed in id is valid
-		assert(mongoose.Types.ObjectId.isValid(req.params.id), errorCodes.E0014);
+		// assert(mongoose.Types.ObjectId.isValid(req.params.id), errorCodes.E0014);
 		const id = mongoose.Types.ObjectId(req.params.id);	
+		console.log("StudentId: ", id);
 
 		//await updateStudyStreak(id);
 

--- a/routes/studentRoutes.js
+++ b/routes/studentRoutes.js
@@ -419,5 +419,4 @@ router.patch('/:id/updateStudyStreak', async (req, res) => {
 	}
 });
 
-
 module.exports = router;


### PR DESCRIPTION
## Description
Backend implementation of the mobile app. PBI [#370](https://github.com/Educado-App/educado-mobile/issues/370).
Students now have a study streak that gets activated when the student triggers a study activity:
- Gives a correct exercise answer and clicks continue.
- Watches a video lecture and clicks continue or swipes.
- Reads a text lecture and clicks continue or swipes.

## Changes
- New attributes to the Student model have been implemented: `studyStreak` and `lastStudyDate`.
- The `studyStreak` value is hooked up to the `Profile` screen where the student can see this streak.
- `studyStreak` is incremented when student does a study activity (but only once a day). 
- The `studyStreak` is reset if the streak has been broken (more than one day has passed since `lastStudyDate`.
- A new route on the back-end has been added: `router.patch('/:id/updateStudyStreak')` for this purpose.
- Unit tests have been written for the back-end, except for the route and the frontend (due to lack of time and man-power).

## Related PR
Mobile PR: [382](https://github.com/Educado-App/educado-mobile/pull/382)

## Checklist
- [x] Code has been tested locally and passes all relevant tests.
- [x] Documentation has been updated to reflect the changes, if applicable.
- [x] Code follows the established coding style and guidelines of the project.
- [x] All new and existing tests related to the changes have passed.
- [x] Any necessary dependencies or new packages have been properly documented.
- [x] Pull request title and description are clear and descriptive.
- [x] Reviewers have been assigned to the pull request.
- [x] Any potential security implications have been considered and addressed.
- [x] Performance impact of the changes has been evaluated, if relevant.
- [x] Changes have been approved by Product Owner
- [x] Code has been analyzed with CodeScene
- [x] I have reviewed the pull request myself
- [x] I have merged the latest version of dev into my branch and resolved conflicts

## Screenshots (if applicable)
**Before a study activity**:
![A](https://github.com/user-attachments/assets/469359ec-d0f3-4d25-8250-a6e24e40dfa9)

**After a study activity**:
![B](https://github.com/user-attachments/assets/a1d9a0a6-4429-4d47-b84d-b58e76e27e03)

## If mobile/frontend pull request, what version of the backend is it stable, and running on? 
Backend:  [feature/study-streak](https://github.com/Educado-App/educado-backend/tree/feature/study-streak) (ver. [32747f4](https://github.com/Educado-App/educado-backend/commit/32747f4041154c33cec17cd84e56aa6f9b553201)).
Mobile: [feature/study-streak](https://github.com/Educado-App/educado-mobile/tree/feature/study-streak) (ver. [9580be5](https://github.com/Educado-App/educado-mobile/commit/9580be51d7c061bc8aa9fc93e4448f0044d7f6cd)).

## Proof of Documentation
**Errors**:
![ERRORS](https://github.com/user-attachments/assets/e3f7e706-a0a5-48d2-a809-31613b28986b)

**Models**:
![MODELS](https://github.com/user-attachments/assets/46091965-71db-4b0c-a2e7-d66307601bc3)